### PR TITLE
provide link for (recommended) course-result

### DIFF
--- a/rasa/KI-Campus_de/action_responses/actions_recommender_responses.yml
+++ b/rasa/KI-Campus_de/action_responses/actions_recommender_responses.yml
@@ -19,6 +19,9 @@ action_get_learning_recommendation:
   # found_course_item parameter {0}: the title of the course
   # found_course_item parameter {1}: the URL-parameter /-ID for the course
   found_course_item: "<a href='https://ki-campus.org/courses/{1}?locale=de' target='_blank' rel='noreferrer noopener'>{0}</a>"
+  # found_course_item_without_code parameter {0}: the title of the course
+  # found_course_item_without_code parameter {1}: URL-encoded string for the title of the course
+  found_course_item_without_code: "<a href='https://ki-campus.org/search/content?keys={1}&locale=de#views-exposed-form-search-content-search' target='_blank' rel='noreferrer noopener'>{0}</a>"
   # found_recommendations_more_single parameter {0}: number (int) of found, additional course recommendations (that are not shown yet)
   found_recommendations_more_single: "... und einen weiteren Kurs"
   # found_recommendations_more_multiple parameter {0}: number (int) of found, additional course recommendations (that are not shown yet)
@@ -42,7 +45,10 @@ action_additional_learning_recommendation:
   additional_recommendations_single: "Also, ich empfehle dir folgenden Kurs: "
   # additional_course_item parameter {0}: the title of the course
   # additional_course_item parameter {1}: the URL-parameter /-ID for the course
-  additional_course_item: "{0}"
+  additional_course_item: "<a href='https://ki-campus.org/courses/{1}?locale=de' target='_blank' rel='noreferrer noopener'>{0}</a>"
+  # additional_course_item_without_code parameter {0}: the title of the course
+  # additional_course_item_without_code parameter {1}: URL-encoded string for the title of the course
+  additional_course_item_without_code: "<a href='https://ki-campus.org/search/content?keys={1}&locale=de#views-exposed-form-search-content-search' target='_blank' rel='noreferrer noopener'>{0}</a>"
   # additional_recommendations_more_single parameter {0}: number (int) of found, additional course recommendations (that are not shown yet)
   additional_recommendations_more_single: "... und einen weiteren Kurs"
   # additional_recommendations_more_multiple parameter {0}: number (int) of found, additional course recommendations (that are not shown yet)

--- a/rasa/KI-Campus_de/action_responses/actions_recommender_responses.yml
+++ b/rasa/KI-Campus_de/action_responses/actions_recommender_responses.yml
@@ -18,7 +18,7 @@ action_get_learning_recommendation:
   found_recommendations_single: "Also, ich empfehle dir folgenden Kurs: "
   # found_course_item parameter {0}: the title of the course
   # found_course_item parameter {1}: the URL-parameter /-ID for the course
-  found_course_item: "{0}"
+  found_course_item: "<a href='https://ki-campus.org/courses/{1}?locale=de' target='_blank' rel='noreferrer noopener'>{0}</a>"
   # found_recommendations_more_single parameter {0}: number (int) of found, additional course recommendations (that are not shown yet)
   found_recommendations_more_single: "... und einen weiteren Kurs"
   # found_recommendations_more_multiple parameter {0}: number (int) of found, additional course recommendations (that are not shown yet)

--- a/rasa/KI-Campus_de/actions/actions_recommender.py
+++ b/rasa/KI-Campus_de/actions/actions_recommender.py
@@ -240,10 +240,16 @@ class ActionGetLearningRecommendation(Action):
 				button_group = []
 				for course in response[0:limit]:
 					title = course['name']
-					url_param = course['id']  # FIXME use course_code when available & create URL for displaying course's website
-					# dispatcher.utter_message(text="* [{0}](https://ki-campus.org/course/{1})".format(title, url_param))
-					button_group.append({"title": course_label.format(title, url_param), "payload": '{0}'.format(title)})
-				dispatcher.utter_message(text=" ", buttons=button_group)  # FIXME non-empty message as WORKAROUND for BUG in socketio-adapter (rasa v3.0-v3.2)
+					url_param = course['course_code']
+					# FIXME [russa] course_code is sometimes empty ... but there is not really a viable alternative, since
+					#               other available IDs/fields cannot be used to directly link to course on the KIC site
+					# HACK: for now, if course_code is not available to not create link, but simply show the course-title
+					btn_title = course_label.format(title, url_param) if url_param else "{}".format(title)
+					# FIXME [russa]: disabled setting a payload with the course-title, since there is no real
+					#                interaction, if payload were to be triggered here
+					btn_payload = ''  # '{0}'.format(title)
+					button_group.append({"title": btn_title, "payload": btn_payload})
+				dispatcher.utter_message(text=" ", buttons=button_group)  # FIXME [russa] non-empty message as WORKAROUND for BUG in socketio-adapter (rasa v3.0-v3.2)
 
 				if limit < size:
 					rest = size - limit
@@ -325,9 +331,16 @@ class ActionAdditionalLearningRecommendation(Action):
 			button_group = []
 			for course in recommendations[0:limit]:
 				title = course['name']
-				url_param = course['id']  # FIXME use course_code when available & create URL for displaying course's website
-				button_group.append({"title": course_label.format(title, url_param), "payload": '{0}'.format(title)})
-			dispatcher.utter_message(text=" ", buttons=button_group)  # FIXME non-empty message as WORKAROUND for BUG in socketio-adapter (rasa v3.0-v3.2)
+				url_param = course['course_code']
+				# FIXME [russa] course_code is sometimes empty ... but there is not really a viable alternative, since
+				#               other available IDs/fields cannot be used to directly link to course on the KIC site
+				# HACK: for now, if course_code is not available to not create link, but simply show the course-title
+				btn_title = course_label.format(title, url_param) if url_param else "{}".format(title)
+				# FIXME [russa]: disabled setting a payload with the course-title, since there is no real
+				#                interaction, if payload were to be triggered here
+				btn_payload = ''  # '{0}'.format(title)
+				button_group.append({"title": btn_title, "payload": btn_payload})
+			dispatcher.utter_message(text=" ", buttons=button_group)  # FIXME [russa] non-empty message as WORKAROUND for BUG in socketio-adapter (rasa v3.0-v3.2)
 
 			if limit < size:
 				rest = size - limit


### PR DESCRIPTION
render web-links for (recommended) course-results

NOTE:
disabled payload for course-result buttons, since currently there is no sensible interaction here (besides opening the web link)